### PR TITLE
feat: unquoted escaping added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use std::arch::is_x86_feature_detected;
+use crate::simd::neon::format_unquote;
 
 mod simd;
 
@@ -320,6 +321,41 @@ fn format_string(value: &str, dst: &mut [u8]) -> usize {
     }
 }
 
+#[inline(always)]
+fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let has_neon = cfg!(target_os = "macos") || std::arch::is_aarch64_feature_detected!("neon");
+        if has_neon {
+            unsafe { simd::neon::format_unquoted(value, dst) }
+        } else {
+            simd::v128::format_string(value, dst)
+        }
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        #[cfg(feature = "avx512")]
+        {
+            if is_x86_feature_detected!("avx512f") {
+                return unsafe { simd::avx512::format_unquote(value, dst) };
+            }
+        }
+        if is_x86_feature_detected!("avx2") {
+            unsafe { simd::avx2::format_unquote(value, dst) }
+        } else if is_x86_feature_detected!("sse2") {
+            unsafe { simd::sse2::format_unquote(value, dst) }
+        } else {
+            simd::v128::format_unquote(value, dst)
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))]
+    {
+        simd::v128::format_string(value, dst)
+    }
+}
+
 pub fn escape(value: &str) -> String {
     let capacity = value.len() * 6 + 32 + 3;
     let mut buf = Vec::with_capacity(capacity);
@@ -332,9 +368,22 @@ pub fn escape(value: &str) -> String {
     unsafe { String::from_utf8_unchecked(buf) }
 }
 
+pub fn escape_unquote(value: &str) -> String {
+    let capacity = value.len() * 6 + 32 + 3;
+    let mut buf = Vec::with_capacity(capacity);
+    #[allow(clippy::uninit_vec)]
+    unsafe {
+        buf.set_len(capacity)
+    };
+    let cnt = format_unquoted(value, &mut buf);
+    unsafe { buf.set_len(cnt) };
+    unsafe { String::from_utf8_unchecked(buf) }
+}
+
 /// # Panics
 ///
-/// Panics if the buffer is not large enough. Allocate enough capacity for dst.
+/// Panics if the buffer is not large enough. Allocate enough capacity for dst,
+/// x6 will be enough in the worst case.
 pub fn escape_into<S: AsRef<str>>(value: S, dst: &mut Vec<u8>) {
     let value = value.as_ref();
     let old_len = dst.len();
@@ -346,6 +395,26 @@ pub fn escape_into<S: AsRef<str>>(value: S, dst: &mut Vec<u8>) {
         let spare =
             std::slice::from_raw_parts_mut(dst.as_mut_ptr().add(old_len), dst.capacity() - old_len);
         let cnt = format_string(value, spare);
+        dst.set_len(old_len + cnt);
+    }
+}
+
+/// Same as escape_into, just without open and close quotes.
+/// # Panics
+///
+/// Panic if the buffer is not large enough. Allocation enough capacity for dst,
+/// x6 will be in the worst case.
+pub fn escape_into_unquote<S: AsRef<str>>(value: S, dst: &mut Vec<u8>) {
+    let value = value.as_ref();
+    let old_len = dst.len();
+
+    // SAFETY: We've reserved enough capacity above, and format_string will
+    // write valid UTF-8 bytes. We'll set the correct length after.
+    unsafe {
+        // Get a slice that includes the spare capacity
+        let spare =
+            std::slice::from_raw_parts_mut(dst.as_mut_ptr().add(old_len), dst.capacity() - old_len);
+        let cnt = format_unquoted(value, spare);
         dst.set_len(old_len + cnt);
     }
 }
@@ -409,6 +478,12 @@ mod tests {
         assert_eq!(escape("\\"), r#""\\""#);
         assert_eq!(escape("\t"), r#""\t""#);
         assert_eq!(escape("\r\n"), r#""\r\n""#);
+    }
+
+    #[test]
+    fn test_unquote() {
+        assert_eq!(escape_unquote("abcd"), "abcd");
+        assert_eq!(escape("abcd"), r#""abcd""#);
     }
 
     #[test]

--- a/src/simd/avx2.rs
+++ b/src/simd/avx2.rs
@@ -4,7 +4,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 use std::ops::{BitAnd, BitOr, BitOrAssign};
-
+use crate::simd::v128::format_raw;
 use super::{Mask, Simd, traits::BitMask, util::escape_unchecked};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -103,17 +103,45 @@ fn escaped_mask(v: Simd256u) -> u32 {
     v.bitmask()
 }
 
-#[target_feature(enable = "avx2")]
-pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
+#[inline(always)]
+pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
-        let mut sptr = slice.as_ptr();
         let mut dptr = dst.as_mut_ptr();
         let dstart = dptr;
         let mut nb: usize = slice.len();
 
         *dptr = b'"';
         dptr = dptr.add(1);
+
+        dptr = format_raw(value, dptr);
+
+        *dptr = b'"';
+        dptr = dptr.add(1);
+        dptr as usize - dstart as usize
+    }
+}
+
+#[inline(always)]
+pub fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut dptr = dst.as_mut_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
+
+        dptr = format_raw(value, dptr);
+
+        dptr as usize - dstart as usize
+    }
+}
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn format_string(value: &str, mut dptr: *mut u8) -> *mut u8 {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut sptr = slice.as_ptr();
+        let mut nb: usize = slice.len();
 
         // Process CHUNK (4 * LANES = 128 bytes) at a time
         while nb >= CHUNK {
@@ -260,8 +288,6 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        *dptr = b'"';
-        dptr = dptr.add(1);
-        dptr as usize - dstart as usize
+        dptr
     }
 }

--- a/src/simd/avx512.rs
+++ b/src/simd/avx512.rs
@@ -4,7 +4,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 use std::ops::{BitAnd, BitOr, BitOrAssign};
-
+use crate::simd::v128::format_raw;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use super::util::check_cross_page;
 use super::{Mask, Simd, traits::BitMask, util::escape_unchecked};
@@ -95,17 +95,48 @@ fn escaped_mask(v: Simd512u) -> u64 {
     v.bitmask()
 }
 
-#[target_feature(enable = "avx512f")]
-pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
+#[inline(always)]
+pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
-        let mut sptr = slice.as_ptr();
         let mut dptr = dst.as_mut_ptr();
         let dstart = dptr;
         let mut nb: usize = slice.len();
 
         *dptr = b'"';
         dptr = dptr.add(1);
+
+        dptr = format_raw(value, dptr);
+
+        *dptr = b'"';
+        dptr = dptr.add(1);
+        dptr as usize - dstart as usize
+    }
+}
+
+#[inline(always)]
+pub fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut dptr = dst.as_mut_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
+
+        dptr = format_raw(value, dptr);
+
+        dptr as usize - dstart as usize
+    }
+}
+
+
+#[inline(always)]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn format_string(value: &str, mut dptr: *mut u8) -> *mut u8 {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut sptr = slice.as_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
 
         // Process CHUNK (4 * LANES = 256 bytes) at a time
         while nb >= CHUNK {
@@ -253,8 +284,6 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        *dptr = b'"';
-        dptr = dptr.add(1);
-        dptr as usize - dstart as usize
+        dptr
     }
 }

--- a/src/simd/neon.rs
+++ b/src/simd/neon.rs
@@ -110,17 +110,45 @@ fn escaped_mask(v: Simd128u) -> NeonBits {
     escaped_mask_vec(v).bitmask()
 }
 
-#[target_feature(enable = "neon")]
-pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
+#[inline(always)]
+pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
-        let mut sptr = slice.as_ptr();
         let mut dptr = dst.as_mut_ptr();
         let dstart = dptr;
         let mut nb: usize = slice.len();
 
         *dptr = b'"';
         dptr = dptr.add(1);
+
+        dptr = crate::simd::v128::format_raw(value, dptr);
+
+        *dptr = b'"';
+        dptr = dptr.add(1);
+        dptr as usize - dstart as usize
+    }
+}
+
+#[inline(always)]
+pub fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut dptr = dst.as_mut_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
+
+        dptr = crate::simd::v128::format_raw(value, dptr);
+
+        dptr as usize - dstart as usize
+    }
+}
+
+#[target_feature(enable = "neon")]
+pub unsafe fn format_raw(value: &str, mut dptr: *mut u8) -> *mut u8 {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut sptr = slice.as_ptr();
+        let mut nb: usize = slice.len();
 
         // Process CHUNK (4 * LANES = 64 bytes) at a time
         while nb >= CHUNK {
@@ -267,8 +295,6 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        *dptr = b'"';
-        dptr = dptr.add(1);
-        dptr as usize - dstart as usize
+        dptr
     }
 }

--- a/src/simd/sse2.rs
+++ b/src/simd/sse2.rs
@@ -100,17 +100,46 @@ fn escaped_mask(v: Simd128u) -> u16 {
     v.bitmask()
 }
 
-#[target_feature(enable = "sse2")]
-pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
+#[inline(always)]
+pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
-        let mut sptr = slice.as_ptr();
         let mut dptr = dst.as_mut_ptr();
         let dstart = dptr;
         let mut nb: usize = slice.len();
 
         *dptr = b'"';
         dptr = dptr.add(1);
+
+        dptr = crate::simd::v128::format_raw(value, dptr);
+
+        *dptr = b'"';
+        dptr = dptr.add(1);
+        dptr as usize - dstart as usize
+    }
+}
+
+#[inline(always)]
+pub fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut dptr = dst.as_mut_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
+
+        dptr = crate::simd::v128::format_raw(value, dptr);
+
+        dptr as usize - dstart as usize
+    }
+}
+
+#[target_feature(enable = "sse2")]
+pub unsafe fn format_raw(value: &str, dptr: *mut u8) -> *mut u8 {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut sptr = slice.as_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
 
         // Process CHUNK (4 * LANES = 64 bytes) at a time
         while nb >= CHUNK {
@@ -257,8 +286,6 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        *dptr = b'"';
-        dptr = dptr.add(1);
-        dptr as usize - dstart as usize
+        dptr
     }
 }

--- a/src/simd/traits.rs
+++ b/src/simd/traits.rs
@@ -1,3 +1,4 @@
+use std::ptr::copy_nonoverlapping;
 use std::ops::{BitAnd, BitOr, BitOrAssign};
 
 /// Portable SIMD traits
@@ -45,4 +46,29 @@ pub trait BitMask {
 
     /// clear high n bits.
     fn clear_high_bits(&self, n: usize) -> Self;
+}
+
+/// Trait to make pointer destinations less cumbersome to deal with.
+pub(crate) trait PointerTrailer {
+    unsafe fn append_byte(self, byte: u8) -> *mut u8;
+
+    unsafe fn append<T: AsRef<[u8]>>(self, src: T) -> *mut u8;
+}
+
+impl PointerTrailer for *mut u8 {
+    unsafe fn append_byte(self, byte: u8) -> *mut u8 {
+        unsafe {
+            *self = byte;
+            self.add(1)
+        }
+    }
+
+    unsafe fn append<T: AsRef<[u8]>>(self, src: T) -> *mut u8 {
+        unsafe {
+            let bytes = src.as_ref();
+            let len = bytes.len();
+            copy_nonoverlapping(bytes.as_ptr(), self, len);
+            self.add(len)
+        }
+    }
 }

--- a/src/simd/v128.rs
+++ b/src/simd/v128.rs
@@ -116,16 +116,45 @@ fn escaped_mask(v: Simd128u) -> u16 {
     v.bitmask()
 }
 
+#[inline(always)]
 pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
-        let mut sptr = slice.as_ptr();
         let mut dptr = dst.as_mut_ptr();
         let dstart = dptr;
         let mut nb: usize = slice.len();
 
         *dptr = b'"';
         dptr = dptr.add(1);
+
+        dptr = format_raw(value, dptr);
+
+        *dptr = b'"';
+        dptr = dptr.add(1);
+        dptr as usize - dstart as usize
+    }
+}
+
+#[inline(always)]
+pub fn format_unquoted(value: &str, dst: &mut [u8]) -> usize {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut dptr = dst.as_mut_ptr();
+        let dstart = dptr;
+        let mut nb: usize = slice.len();
+
+        dptr = format_raw(value, dptr);
+
+        dptr as usize - dstart as usize
+    }
+}
+
+
+pub fn format_raw(value: &str, mut dptr: *mut u8) -> *mut u8 {
+    unsafe {
+        let slice = value.as_bytes();
+        let mut sptr = slice.as_ptr();
+        let mut nb: usize = slice.len();
 
         // Main loop: process LANES bytes at a time
         while nb >= LANES {
@@ -191,8 +220,6 @@ pub fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        *dptr = b'"';
-        dptr = dptr.add(1);
-        dptr as usize - dstart as usize
+        dptr
     }
 }


### PR DESCRIPTION
I have a case where I construct keys with concatenation. Need to concatenate in a standalone buffer with the current API, meaning excessive copying. The proposed "unquoted" API solves this issue.

- I moved actual formatting logic from `format_string` to `format_raw`
- I decided to put `#[inline(always)]` on `format_string` and `format_unquoted`. My first intention was to keep public inline semantics and put that `#[inline(always)]` on `format_raw` functions, but there're issues with inlining and `target_feature`. Anyway, both `format_string` and `format_unquoted` are tiny now, so this should not change much compared to what it have been. 
