### PR TITLE
feat(avx512): working, optimized AVX-512 escape kernel + escape_into overflow fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,9 @@ fn format_string(value: &str, dst: &mut [u8]) -> usize {
     {
         #[cfg(feature = "avx512")]
         {
-            if is_x86_feature_detected!("avx512f") {
+            // The avx512 kernel uses AVX-512BW byte compares (vpcmpub) and
+            // masked loads/stores (VL), so require both at runtime, not just F.
+            if is_x86_feature_detected!("avx512bw") && is_x86_feature_detected!("avx512vl") {
                 return unsafe { simd::avx512::format_string(value, dst) };
             }
         }
@@ -332,15 +334,23 @@ pub fn escape(value: &str) -> String {
     unsafe { String::from_utf8_unchecked(buf) }
 }
 
-/// # Panics
-///
-/// Panics if the buffer is not large enough. Allocate enough capacity for dst.
+/// Escapes `value` (including the surrounding `"`) and appends the result to
+/// `dst`, growing `dst` as needed.
 pub fn escape_into<S: AsRef<str>>(value: S, dst: &mut Vec<u8>) {
     let value = value.as_ref();
+
+    // The SIMD kernels perform full-register speculative stores and copy 8 bytes
+    // per escape, so they need up to `len * 6 + 32 + 3` scratch bytes past the
+    // current end regardless of the final output length. Reserve that up front
+    // so the unchecked writes below can never exceed the allocation. `reserve`
+    // is effectively free when the caller already sized `dst` large enough.
+    dst.reserve(value.len() * 6 + 32 + 3);
     let old_len = dst.len();
 
-    // SAFETY: We've reserved enough capacity above, and format_string will
-    // write valid UTF-8 bytes. We'll set the correct length after.
+    // SAFETY: the `reserve` above guarantees `dst.capacity() - old_len` is at
+    // least `value.len() * 6 + 32 + 3`, which upper-bounds every store
+    // `format_string` performs. It writes valid UTF-8 and returns the number of
+    // bytes written, which we then commit as the new length.
     unsafe {
         // Get a slice that includes the spare capacity
         let spare =

--- a/src/simd/avx512.rs
+++ b/src/simd/avx512.rs
@@ -5,8 +5,6 @@ use std::arch::x86_64::*;
 
 use std::ops::{BitAnd, BitOr, BitOrAssign};
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use super::util::check_cross_page;
 use super::{Mask, Simd, traits::BitMask, util::escape_unchecked};
 
 const LANES: usize = 64;
@@ -95,7 +93,7 @@ fn escaped_mask(v: Simd512u) -> u64 {
     v.bitmask()
 }
 
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vl")]
 pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
     unsafe {
         let slice = value.as_bytes();
@@ -121,8 +119,9 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             let mask3 = escaped_mask(v3);
             let mask4 = escaped_mask(v4);
 
-            // Fast path: if all vectors are clean, write the entire chunk
-            if mask1.all_zero() && mask2.all_zero() && mask3.all_zero() && mask4.all_zero() {
+            // Fast path: single OR-combined mask test => 1 branch, lets the 4
+            // independent load+mask dependency chains pipeline in parallel.
+            if (mask1 | mask2 | mask3 | mask4) == 0 {
                 v1.storeu(dptr);
                 v2.storeu(dptr.add(LANES));
                 v3.storeu(dptr.add(LANES * 2));
@@ -209,36 +208,19 @@ pub unsafe fn format_string(value: &str, dst: &mut [u8]) -> usize {
             }
         }
 
-        // Handle remaining bytes
-        let mut placeholder: [u8; LANES] = [0; LANES];
-        let mut v;
+        // Handle the remaining (< LANES) bytes with an AVX-512BW masked load +
+        // masked store. `nb` is always in 1..=63 here, so k has 1..=63 low bits
+        // set. The zero-masking load `_mm512_maskz_loadu_epi8` suppresses faults
+        // on the masked-off (high) lanes, so it never reads past the valid input
+        // -> page-safe without any placeholder copy. The masked store writes
+        // exactly `nb` bytes, so it also never touches memory beyond the logical
+        // output. The high (masked-off) lanes read as zero, which would look like
+        // escape candidates (0x00 <= 0x1f), so we clear the top LANES-nb mask
+        // bits exactly as the scalar path did.
         while nb > 0 {
-            v = {
-                #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-                {
-                    std::ptr::copy_nonoverlapping(sptr, placeholder[..].as_mut_ptr(), nb);
-                    Simd512u::loadu(placeholder[..].as_ptr())
-                }
-                #[cfg(any(target_os = "linux", target_os = "macos"))]
-                {
-                    if check_cross_page(sptr, LANES) {
-                        std::ptr::copy_nonoverlapping(sptr, placeholder[..].as_mut_ptr(), nb);
-                        Simd512u::loadu(placeholder[..].as_ptr())
-                    } else {
-                        #[cfg(any(debug_assertions, miri, feature = "asan"))]
-                        {
-                            std::ptr::copy_nonoverlapping(sptr, placeholder[..].as_mut_ptr(), nb);
-                            Simd512u::loadu(placeholder[..].as_ptr())
-                        }
-                        #[cfg(not(any(debug_assertions, miri)))]
-                        {
-                            Simd512u::loadu(sptr)
-                        }
-                    }
-                }
-            };
-
-            v.storeu(std::slice::from_raw_parts_mut(dptr, LANES).as_mut_ptr());
+            let k: __mmask64 = (1u64 << nb) - 1;
+            let v = Simd512u(_mm512_maskz_loadu_epi8(k, sptr as *const i8));
+            _mm512_mask_storeu_epi8(dptr as *mut i8, k, v.0);
             let mask = escaped_mask(v).clear_high_bits(LANES - nb);
 
             if mask.all_zero() {

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1,0 +1,72 @@
+//! Differential + buffer-safety stress test.
+//!
+//! Regression guard for the SIMD kernels' tail handling. Escapes strings of
+//! every length across many escape densities and compares against `serde_json`.
+//! This exercises every `len % LANES` tail remainder, the 64/256-byte chunk
+//! boundaries, and worst-case 6x expansion (`\u00xx`) — exactly the paths that
+//! must never write past the destination buffer.
+
+use json_escape_simd::escape;
+
+#[track_caller]
+fn check(s: &str) {
+    assert_eq!(
+        escape(s),
+        serde_json::to_string(s).unwrap(),
+        "mismatch for input of len {}",
+        s.len()
+    );
+}
+
+#[test]
+fn stress_all_lengths_and_densities() {
+    // Fills spanning 6x expansion (control chars), 2x (\\ " \n) and clean.
+    let fills: [char; 6] = ['\u{0}', '"', '\\', '\n', 'a', '\u{1f}'];
+    for len in 0..=600usize {
+        for &f in &fills {
+            let s: String = std::iter::repeat(f).take(len).collect();
+            check(&s);
+        }
+        if len > 0 {
+            // single escape at the very end (tail-boundary trigger)
+            let mut s: String = std::iter::repeat('a').take(len - 1).collect();
+            s.push('"');
+            check(&s);
+            // single escape at the very start
+            let mut s2 = String::from("\"");
+            s2.extend(std::iter::repeat('a').take(len - 1));
+            check(&s2);
+        }
+    }
+}
+
+#[test]
+fn escape_into_never_overflows_exact_capacity() {
+    use json_escape_simd::escape_into;
+    // `escape_into` must not write out of bounds even when the caller sizes the
+    // destination to exactly the final output length (or less). Cover a range of
+    // lengths and densities; grows are fine, overruns are UB.
+    let fills: [char; 4] = ['\u{0}', '"', '\\', 'a'];
+    for len in 0..=300usize {
+        for &f in &fills {
+            let input: String = std::iter::repeat(f).take(len).collect();
+            let expected = serde_json::to_string(&input).unwrap();
+            let mut dst = Vec::with_capacity(expected.len()); // exact, no slack
+            escape_into(&input, &mut dst);
+            assert_eq!(dst, expected.as_bytes(), "len {len} fill {f:?}");
+        }
+    }
+}
+
+#[test]
+fn stress_multibyte_utf8_boundaries() {
+    // Bytes >= 0x80 (UTF-8 lead/continuation) must pass through unescaped,
+    // including right at chunk/lane boundaries.
+    for len in 0..=200usize {
+        let mut s: String = std::iter::repeat('a').take(len).collect();
+        s.push('中'); // 3-byte UTF-8
+        s.push('"'); // followed by an escape
+        s.push('𝄞'); // 4-byte UTF-8
+        check(&s);
+    }
+}

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -24,17 +24,17 @@ fn stress_all_lengths_and_densities() {
     let fills: [char; 6] = ['\u{0}', '"', '\\', '\n', 'a', '\u{1f}'];
     for len in 0..=600usize {
         for &f in &fills {
-            let s: String = std::iter::repeat(f).take(len).collect();
+            let s: String = std::iter::repeat_n(f, len).collect();
             check(&s);
         }
         if len > 0 {
             // single escape at the very end (tail-boundary trigger)
-            let mut s: String = std::iter::repeat('a').take(len - 1).collect();
+            let mut s = "a".repeat(len - 1);
             s.push('"');
             check(&s);
             // single escape at the very start
             let mut s2 = String::from("\"");
-            s2.extend(std::iter::repeat('a').take(len - 1));
+            s2.extend(std::iter::repeat_n('a', len - 1));
             check(&s2);
         }
     }
@@ -49,7 +49,7 @@ fn escape_into_never_overflows_exact_capacity() {
     let fills: [char; 4] = ['\u{0}', '"', '\\', 'a'];
     for len in 0..=300usize {
         for &f in &fills {
-            let input: String = std::iter::repeat(f).take(len).collect();
+            let input: String = std::iter::repeat_n(f, len).collect();
             let expected = serde_json::to_string(&input).unwrap();
             let mut dst = Vec::with_capacity(expected.len()); // exact, no slack
             escape_into(&input, &mut dst);
@@ -63,7 +63,7 @@ fn stress_multibyte_utf8_boundaries() {
     // Bytes >= 0x80 (UTF-8 lead/continuation) must pass through unescaped,
     // including right at chunk/lane boundaries.
     for len in 0..=200usize {
-        let mut s: String = std::iter::repeat('a').take(len).collect();
+        let mut s = "a".repeat(len);
         s.push('中'); // 3-byte UTF-8
         s.push('"'); // followed by an escape
         s.push('𝄞'); // 4-byte UTF-8


### PR DESCRIPTION
## Summary

Makes the `avx512` feature a **real, faster** JSON-escape kernel. It existed but had never run on AVX-512 hardware and was a **regression** two ways:

1. `#[target_feature(enable = "avx512f")]` alone → LLVM **emulates** the u8 byte compares (there's no native `vpcmpub` under plain F) → **~1.75× slower than avx2**.
2. The `<64B` tail did a **64-byte speculative store** that overflowed the destination buffer for short/dense inputs (heap-buffer-overflow → SIGABRT; caught the first time the feature was ever tested).

Verified end-to-end on an Intel **Xeon Platinum 8581C (Emerald Rapids)** VM.

## Changes

**`src/simd/avx512.rs`**
- Enable `avx512f,avx512bw,avx512vl` so LLVM emits native `vpcmpub` + `korq` + `kortestq`.
- Fast path: one OR-combined mask branch per 256B chunk — `(m1|m2|m3|m4)==0` — instead of 4 short-circuit `&&` branches. One branch, and the four load+mask chains pipeline.
- Tail (`<64B`): AVX-512 masked load/store — `k=(1u64<<nb)-1`, `_mm512_maskz_loadu_epi8` (page-safe, never reads past valid bytes) + `_mm512_mask_storeu_epi8` (writes exactly `nb`). Removes the old over-store, so `escape()` keeps the upstream `len*6+32+3` allocation.

**`src/lib.rs`**
- Dispatch gates the avx512 kernel on runtime `is_x86_feature_detected!("avx512bw") && ("avx512vl")` (not just `avx512f`), matching the enabled features.
- Fixes a **pre-existing** soundness hole (not avx512-specific): `escape_into` never reserved capacity, so a caller buffer sized to the exact output could overflow. Confirmed under **ASAN** on both the default avx2 path (32-byte write) and the avx512 path (8-byte write via `escape_unchecked`). Now `reserve(len*6+32+3)` up front — a no-op when the caller already sized `dst`.

**`tests/stress.rs`** (new)
- Brute-force differential vs `serde_json` across all lengths `0..=600` × escape densities × boundary/multibyte.
- `escape_into` exact-capacity regression (the overflow trigger).

## How I picked the kernel

Benchmarked 6 candidate variants **serially** on the one CPU (the only valid comparison), each first passing a 16-test correctness gate. Winners: combined-branch + masked tail. Measured **worse** on this µarch and rejected: 8×-unroll (register spill, +56% on rxjs), software prefetch, non-temporal stores, `vpshufb` nibble-LUT classifier.

## Benchmarks (Xeon 8581C, `--features avx512`)

| bench | this PR | avx2 (prior) | sonic-rs | old avx512f-only |
|---|---|---|---|---|
| rxjs | **249 µs** | 289 µs | 311 µs | 505 µs |
| fixtures (127 MB) | **10.31 ms** | 11.04 ms | 11.66 ms | 19.53 ms |
| short string | **80 ns** | 84 ns | 202 ns | 105 ns |

Fixtures is memory-bandwidth-bound (out-of-cache) and sits near the ceiling.

## Verification
- 16 unit + 3 stress tests pass with **both** `--features avx512` and the default (avx2) build.
- **ASAN** clean on both paths (incl. the exact-capacity `escape_into` case that previously overflowed).

## Notes
- The `avx512` feature is still **opt-in** (`--features avx512`). Happy to make it default-on with runtime detection if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
